### PR TITLE
feature/0.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     }
   },
   "scripts": {
-    "test": "phpunit --coverage-clover=coverage.xml"
+    "test": "php vendor/bin/phpunit --coverage-clover=coverage.xml"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.5",
-    "phpunit/phpunit": "^8"
+    "phpunit/phpunit": "^8.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "490e2edad2328b1bd607884f6cf7b41f",
+    "content-hash": "6648937536dff553db00b75fd9051b4d",
     "packages": [
         {
             "name": "alex-patterson-webdev/factory",
@@ -763,16 +763,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.2",
+            "version": "8.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0"
+                "reference": "67750516bc02f300e2742fed2f50177f8f37bedf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
-                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/67750516bc02f300e2742fed2f50177f8f37bedf",
+                "reference": "67750516bc02f300e2742fed2f50177f8f37bedf",
                 "shasum": ""
             },
             "require": {
@@ -842,7 +842,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:49:49+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-03-31T08:52:04+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1512,16 +1522,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
@@ -1533,7 +1543,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -1566,7 +1576,21 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-01-13T11:15:53+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1658,7 +1682,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/Listener/ListenerCollection.php
+++ b/src/Listener/ListenerCollection.php
@@ -13,7 +13,7 @@ class ListenerCollection implements ListenerCollectionInterface
     /**
      * The collection of listeners to iterate.
      *
-     * @var \SplPriorityQueue|callable[]
+     * @var PriorityQueue|callable[]
      */
     private $listeners;
 
@@ -29,7 +29,7 @@ class ListenerCollection implements ListenerCollectionInterface
      */
     public function __construct(iterable $listeners = [])
     {
-        $this->listeners = new \SplPriorityQueue();
+        $this->listeners = new PriorityQueue();
 
         if (!empty($listeners)) {
             $this->addListeners($listeners);
@@ -67,11 +67,10 @@ class ListenerCollection implements ListenerCollectionInterface
      */
     public function getIterator(): \Traversable
     {
-        $clone = clone $this->listeners;
+        $iterator = clone $this->listeners;
+        $iterator->rewind();
 
-        $clone->rewind();
-
-        return $clone;
+        return $iterator;
     }
 
     /**

--- a/src/Listener/ListenerCollection.php
+++ b/src/Listener/ListenerCollection.php
@@ -22,7 +22,7 @@ class ListenerCollection implements ListenerCollectionInterface
      *
      * @var int
      */
-    private $queueOrder = PHP_INT_MIN;
+    private $queueOrder = PHP_INT_MAX;
 
     /**
      * @param iterable|callable[] $listeners
@@ -57,7 +57,7 @@ class ListenerCollection implements ListenerCollectionInterface
      */
     public function addListener(callable $listener, int $priority = 1): void
     {
-        $this->listeners->insert($listener, [$priority, $this->queueOrder++]);
+        $this->listeners->insert($listener, [$priority, $this->queueOrder--]);
     }
 
     /**

--- a/src/Listener/PriorityQueue.php
+++ b/src/Listener/PriorityQueue.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arp\EventDispatcher\Listener;
+
+/**
+ * @author  Alex Patterson <alex.patterson.webdev@gmail.com>
+ * @package Arp\EventDispatcher\Listener
+ */
+final class PriorityQueue extends \SplPriorityQueue
+{
+    /**
+     * Compare the priorities.
+     *
+     * @param mixed $priority1
+     * @param mixed $priority2
+     *
+     * @return int
+     */
+    public function compare($priority1, $priority2): int
+    {
+        return ($priority1 <=> $priority2);
+    }
+}

--- a/test/phpunit/Listener/ListenerCollectionTest.php
+++ b/test/phpunit/Listener/ListenerCollectionTest.php
@@ -168,6 +168,61 @@ final class ListenerCollectionTest extends TestCase
             $results[] = $item();
         }
 
-        $this->assertSame([1,2,3,4,5,6,7,8], $results);
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8], $results);
+    }
+
+    /**
+     * Assert that the listeners natural order is respected when provided with event listeners with the same
+     * priorities. This means that the collection operates on a first in first out basis.
+     *
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::addListener
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::addListeners
+     */
+    public function testListenerPrioritiesRespectNaturalOrderWhenPrioritiesAreTheSame(): void
+    {
+        $listeners = [
+            static function () {
+                return 5;
+            },
+            static function () {
+                return 1;
+            },
+            static function () {
+                return 3;
+            },
+            static function () {
+                return 7;
+            },
+            static function () {
+                return 4;
+            },
+            static function () {
+                return 8;
+            },
+            static function () {
+                return 6;
+            },
+            static function () {
+                return 2;
+            },
+        ];
+
+        $collection = new ListenerCollection();
+
+        $collection->addListener($listeners[0], 1); // 5
+        $collection->addListener($listeners[1], 1); // 1
+        $collection->addListener($listeners[2], 1); // 3
+        $collection->addListener($listeners[3], 1); // 7
+        $collection->addListener($listeners[4], 1); // 4
+        $collection->addListener($listeners[5], 1); // 8
+        $collection->addListener($listeners[6], 1); // 6
+        $collection->addListener($listeners[7], 1); // 2
+
+        $results = [];
+        foreach ($collection as $item) {
+            $results[] = $item();
+        }
+
+        $this->assertSame([5, 1, 3, 7, 4, 8, 6, 2], $results);
     }
 }

--- a/test/phpunit/Listener/ListenerCollectionTest.php
+++ b/test/phpunit/Listener/ListenerCollectionTest.php
@@ -17,7 +17,7 @@ final class ListenerCollectionTest extends TestCase
     /**
      * Assert that the listener collection implements ListenerCollectionInterface.
      *
-     * @test
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection
      */
     public function testImplementsListenerCollectionInterface(): void
     {
@@ -27,50 +27,31 @@ final class ListenerCollectionTest extends TestCase
     }
 
     /**
-     * Assert that
+     * Assert that getIterator() will return a clone of the listener priority queue.
      *
-     * @test
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::getIterator
      */
     public function testGetIteratorWillReturnCloneOfListenerQueue(): void
     {
         $collection = new ListenerCollection();
 
         $listeners = [
-            static function () {
-                return '0';
+            'Foo' => static function () {
+                return 'Foo';
             },
-            static function () {
-                return '1';
-            },
-            static function () {
-                return '2';
-            },
-            static function () {
-                return '3';
-            },
-            static function () {
-                return '4';
-            },
-            static function () {
-                return '5';
+            'Bar' => static function () {
+                return 'Bar';
             },
         ];
 
-        foreach ($listeners as $index => $listener) {
-            $collection->addListener($listener, 10);
+        $collection->addListeners($listeners, 1);
+
+        $results = [];
+        foreach ($collection as $index => $listener) {
+            $results[] = $listener();
         }
 
-        $cloneOfQueue = $collection->getIterator();
-
-        foreach ($cloneOfQueue as $index => $item) {
-            $expected = $listeners[$index]();
-            $value = $item();
-
-            $this->assertSame(
-                $expected,
-                $value, sprintf('Index \'%d\' is invalid', $index)
-            );
-        }
+        $this->assertSame(['Foo', 'Bar'], $results);
     }
 
     /**
@@ -80,7 +61,7 @@ final class ListenerCollectionTest extends TestCase
      */
     public function testCountWillReturnIntegerMatchingTheNumberOfEventListeners(): void
     {
-        $collection = new ListenerCollection;
+        $collection = new ListenerCollection();
 
         /** @var callable[] $listeners */
         $listeners = [
@@ -106,6 +87,12 @@ final class ListenerCollectionTest extends TestCase
      */
     public function testEventListenersCanBeAddedViaConstructor(): void
     {
+        $expected = [
+            'foo',
+            'bar',
+            'baz',
+        ];
+
         $listeners = [
             static function () {
                 return 'foo';
@@ -120,10 +107,67 @@ final class ListenerCollectionTest extends TestCase
 
         $collection = new ListenerCollection($listeners);
 
-        foreach ($collection->getIterator() as $index => $listener) {
-            $this->assertSame($listeners[$index], $listener);
+        $results = [];
+        foreach ($collection as $index => $listener) {
+            $results[] = $listener();
         }
 
+        $this->assertSame($expected, $results);
         $this->assertSame(count($listeners), $collection->count());
+    }
+
+    /**
+     * Assert that the listeners priorities are respected, regardless of when the listener is registered with the
+     * collection.
+     *
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::addListener
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::addListeners
+     */
+    public function testListenerPriorities(): void
+    {
+        $listeners = [
+            static function () {
+                return 5;
+            },
+            static function () {
+                return 1;
+            },
+            static function () {
+                return 3;
+            },
+            static function () {
+                return 7;
+            },
+            static function () {
+                return 4;
+            },
+            static function () {
+                return 8;
+            },
+            static function () {
+                return 6;
+            },
+            static function () {
+                return 2;
+            },
+        ];
+
+        $collection = new ListenerCollection();
+
+        $collection->addListener($listeners[0], 300); // 5
+        $collection->addListener($listeners[1], 700); // 1
+        $collection->addListener($listeners[2], 500); // 3
+        $collection->addListener($listeners[3], 101); // 7
+        $collection->addListener($listeners[4], 400); // 4
+        $collection->addListener($listeners[5], 100); // 8
+        $collection->addListener($listeners[6], 200); // 6
+        $collection->addListener($listeners[7], 600); // 2
+
+        $results = [];
+        foreach ($collection as $item) {
+            $results[] = $item();
+        }
+
+        $this->assertSame([1,2,3,4,5,6,7,8], $results);
     }
 }

--- a/test/phpunit/Listener/ListenerCollectionTest.php
+++ b/test/phpunit/Listener/ListenerCollectionTest.php
@@ -57,7 +57,7 @@ final class ListenerCollectionTest extends TestCase
     /**
      * Assert that the count() method will return an integer matching the number of listeners added to the collection.
      *
-     * @test
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection::addListeners
      */
     public function testCountWillReturnIntegerMatchingTheNumberOfEventListeners(): void
     {
@@ -83,7 +83,7 @@ final class ListenerCollectionTest extends TestCase
     /**
      * Assert that we can add a collection of event listeners via the __construct.
      *
-     * @test
+     * @covers \Arp\EventDispatcher\Listener\ListenerCollection
      */
     public function testEventListenersCanBeAddedViaConstructor(): void
     {

--- a/test/phpunit/Listener/ListenerProviderTest.php
+++ b/test/phpunit/Listener/ListenerProviderTest.php
@@ -8,7 +8,6 @@ use Arp\EventDispatcher\Listener\Exception\EventListenerException;
 use Arp\EventDispatcher\Listener\ListenerCollection;
 use Arp\EventDispatcher\Listener\ListenerCollectionInterface;
 use Arp\EventDispatcher\Listener\ListenerProvider;
-use Arp\EventDispatcher\Listener\PriorityQueue;
 use Arp\EventDispatcher\Resolver\EventNameResolverInterface;
 use Arp\EventDispatcher\Resolver\Exception\EventNameResolverException;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/test/phpunit/Listener/ListenerProviderTest.php
+++ b/test/phpunit/Listener/ListenerProviderTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace ArpTest\EventDispatcher\Listener;
 
 use Arp\EventDispatcher\Listener\Exception\EventListenerException;
+use Arp\EventDispatcher\Listener\ListenerCollection;
 use Arp\EventDispatcher\Listener\ListenerCollectionInterface;
 use Arp\EventDispatcher\Listener\ListenerProvider;
+use Arp\EventDispatcher\Listener\PriorityQueue;
 use Arp\EventDispatcher\Resolver\EventNameResolverInterface;
 use Arp\EventDispatcher\Resolver\Exception\EventNameResolverException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -58,6 +60,10 @@ final class ListenerProviderTest extends TestCase
     {
         $provider = new ListenerProvider($this->eventNameResolver);
 
+        $this->eventNameResolver
+            ->method('resolveEventName')
+            ->willReturn(\stdClass::class);
+
         $event = new \stdClass();
 
         $provider->addListenersForEvent($event, $listeners);
@@ -66,13 +72,17 @@ final class ListenerProviderTest extends TestCase
 
         $this->assertInstanceOf(ListenerCollectionInterface::class, $collection);
 
-        $listeners = ($listeners instanceof \Traversable)
-            ? iterator_to_array($listeners)
-            : $listeners;
-
-        foreach ($collection as $index => $item) {
-            $this->assertSame($listeners[$index], $item);
+        $expected = [];
+        foreach ($listeners as $listener) {
+            $expected[] = $listener($event);
         }
+
+        $actual = [];
+        foreach ($collection as $listener) {
+            $actual[] = $listener($event);
+        }
+
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -80,20 +90,6 @@ final class ListenerProviderTest extends TestCase
      */
     public function getAddListenersForEventAndGetListenerForEventData(): array
     {
-        $collectionIterator = new \ArrayObject([
-            static function ($event) {
-            },
-            static function ($event) {
-            },
-            static function ($event) {
-            },
-        ]);
-
-        $collection = $this->getMockForAbstractClass(ListenerCollectionInterface::class);
-        $collection->expects($this->exactly(2))
-            ->method('getIterator')
-            ->willReturn($collectionIterator);
-
         return [
 
             // Empty listener collection test...
@@ -105,7 +101,7 @@ final class ListenerProviderTest extends TestCase
             [
                 [
                     static function (\stdClass $event) {
-                        return $event->foo ?? 'Bar';
+                        return 1;
                     },
                 ],
             ],
@@ -114,20 +110,30 @@ final class ListenerProviderTest extends TestCase
             [
                 [
                     static function (\stdClass $event) {
-                        return $event->foo ?? 'Bar';
+                        return 0;
                     },
                     static function (\stdClass $event) {
-                        return $event->foo ?? 'Bar';
+                        return 1;
                     },
                     static function (\stdClass $event) {
-                        return $event->foo ?? 'Bar';
+                        return 2;
                     },
                 ],
             ],
 
             // Traversable test
             [
-                $collection,
+                new ListenerCollection([
+                    static function ($event) {
+                        return 0;
+                    },
+                    static function ($event) {
+                        return 1;
+                    },
+                    static function ($event) {
+                        return 2;
+                    },
+                ]),
             ],
         ];
     }
@@ -141,7 +147,7 @@ final class ListenerProviderTest extends TestCase
     {
         $provider = new ListenerProvider($this->eventNameResolver);
 
-        $event = new \stdClass;
+        $event = new \stdClass();
 
         $exceptionMessage = 'Test exception message';
         $exception = new EventNameResolverException($exceptionMessage);

--- a/test/phpunit/Listener/PriorityQueueTest.php
+++ b/test/phpunit/Listener/PriorityQueueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArpTest\EventDispatcher\Listener;
+
+use Arp\EventDispatcher\Listener\PriorityQueue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author  Alex Patterson <alex.patterson.webdev@gmail.com>
+ * @package ArpTest\EventDispatcher\Listener
+ */
+final class PriorityQueueTest extends TestCase
+{
+    /**
+     * Assert that the class extends from the \SplPriorityQueue.
+     *
+     * @covers \Arp\EventDispatcher\Listener\PriorityQueue
+     */
+    public function testExtendsSplPriorityQueue(): void
+    {
+        $priorityQueue = new PriorityQueue();
+
+        $this->assertInstanceOf(\SplPriorityQueue::class, $priorityQueue);
+    }
+
+    /**
+     * Assert that the priority queue's comparision returns the expeceted result when provided with various
+     * different priority values.
+     *
+     * @param mixed $priority1
+     * @param mixed $priority2
+     *
+     * @dataProvider getCompareData
+     *
+     * @covers \Arp\EventDispatcher\Listener\PriorityQueue::compare
+     */
+    public function testCompare($priority1, $priority2): void
+    {
+        $priorityQueue = new PriorityQueue();
+
+        $this->assertSame(
+            ($priority1 <=> $priority2),
+            $priorityQueue->compare($priority1, $priority2)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getCompareData(): array
+    {
+        return [
+            [1, 1],
+            [100, 200],
+            [300, 1],
+            [2345, 999],
+            [1, 1],
+            [1000,1000],
+            [
+                [1, 100],
+                [1, 100],
+            ],
+            [
+                [1000, 12398612],
+                [1000, 92398612],
+            ],
+            [
+                [1239840, 100],
+                [10354561, 1123123],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fix `ListenerCollection` ordering by reversing the interface pointer reference to `PHP_INT_MAX` and added new test coverage to ensure the priorities and orderings are respected.